### PR TITLE
Fix login form google login

### DIFF
--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {RiZzzFill} from "react-icons/ri";
-// import { loginWithGoogle } from "@/lib/appwrite/auth";
+import { loginWithGoogle } from "@/lib/appwrite/auth";
 
 export function LoginForm({
   className,

--- a/lib/appwrite/auth.ts
+++ b/lib/appwrite/auth.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { Account, Client } from "appwrite";
+import { appwriteConfig } from "@/lib/appwrite/config";
+
+/**
+ * Creates an OAuth2 session with Google using Appwrite.
+ * Redirects the user to the Appwrite OAuth2 consent screen.
+ */
+export async function loginWithGoogle() {
+  const client = new Client()
+    .setEndpoint(appwriteConfig.endpointUrl)
+    .setProject(appwriteConfig.projectId);
+
+  const account = new Account(client);
+
+  try {
+    // Redirect back to the root page after successful or failed login
+    await account.createOAuth2Session("google", "/", "/");
+  } catch (error) {
+    console.error("Failed to sign in with Google", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- implement a stub Appwrite Google OAuth helper
- wire up login form to use new helper

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_68589af831808331a239d65a2d696f51